### PR TITLE
Fix index names to be able to db:rollback the migrations

### DIFF
--- a/lib/generators/reputation_system/templates/add_evaluations_index.rb
+++ b/lib/generators/reputation_system/templates/add_evaluations_index.rb
@@ -20,6 +20,6 @@ class AddEvaluationsIndex < ActiveRecord::Migration
   end
 
   def self.down
-    remove_index :rs_evaluations, :column => [:reputation_name, :source_id, :source_type, :target_id, :target_type]
+    remove_index :rs_evaluations, :name => "index_rs_evaluations_on_reputation_name_and_source_and_target"
   end
 end

--- a/lib/generators/reputation_system/templates/add_reputation_messages_index.rb
+++ b/lib/generators/reputation_system/templates/add_reputation_messages_index.rb
@@ -20,6 +20,6 @@ class AddReputationMessagesIndex < ActiveRecord::Migration
   end
 
   def self.down
-    remove_index :rs_reputation_messages, :column => [:receiver_id, :sender_id, :sender_type]
+    remove_index :rs_reputation_messages, :name => "index_rs_reputation_messages_on_receiver_id_and_sender"
   end
 end

--- a/lib/generators/reputation_system/templates/add_reputations_index.rb
+++ b/lib/generators/reputation_system/templates/add_reputations_index.rb
@@ -20,6 +20,6 @@ class AddReputationsIndex < ActiveRecord::Migration
   end
 
   def self.down
-    remove_index :rs_reputations, :column => [:reputation_name, :target_id, :target_type]
+    remove_index :rs_reputations, :name => "index_rs_reputations_on_reputation_name_and_target"
   end
 end


### PR DESCRIPTION
I'm using rails 3.2.5.

When I rolled back the migration of the gem I got errors saying `index name doesn't exist`. I found that the generated index name in the `down` method in the migration is different from the ones in the `up`.

I made a quick fix and it works for me.
