### PR TITLE
auto-require 'reputation_system'

### DIFF
--- a/lib/activerecord-reputation-system.rb
+++ b/lib/activerecord-reputation-system.rb
@@ -1,0 +1,1 @@
+require 'reputation_system'


### PR DESCRIPTION
That allows to bundle this gem simply by adding to Gemfile:

``` ruby
gem 'activerecord-reputation-system'
```

Probably needs a README update too (for future versions).
