### PR TITLE
Corrected returned value of EvaluationMethods#evaluators_for method

### DIFF
--- a/lib/reputation_system/evaluation_methods.rb
+++ b/lib/reputation_system/evaluation_methods.rb
@@ -43,7 +43,8 @@ module ReputationSystem
     def evaluators_for(reputation_name, *args)
       scope = args.first
       srn = ReputationSystem::Network.get_scoped_reputation_name(self.class.name, reputation_name, scope)
-      self.evaluations.for(srn).includes(:source).map(&:source)
+      ReputationSystem::Evaluation.where(target_id: self.id, target_type: self.class.name, reputation_name: srn)
+        .collect(&:source_id).collect{ |id| User.find(id) }
     end
 
     def add_evaluation(reputation_name, value, source, *args)


### PR DESCRIPTION
Running @answer.evaluators_for(:answer_reputation) in console

invokes

```
ReputationSystem::Evaluation Load (0.6ms)  SELECT "rs_evaluations".* FROM "rs_evaluations" WHERE "rs_evaluations"."target_id" = 131 AND "rs_evaluations"."target_type" = 'Answer' AND "rs_evaluations"."reputation_name" = 'answer_reputation'
```

It returns Evaluations not evaluators (in my case 'users') as opposed to the wiki.

https://github.com/twitter/activerecord-reputation-system/issues/56
