### PR TITLE
Add #scope_with_reputation method to return scoped object instead of Array

### DIFF
--- a/lib/reputation_system/finder_methods.rb
+++ b/lib/reputation_system/finder_methods.rb
@@ -58,6 +58,14 @@ module FinderMethods
         end
       end
 
+      def scope_with_reputation(*args)
+        reputation_name, srn, find_scope, options = parse_query_args(*args)
+        select_query = build_select_statement(table_name, reputation_name, options[:select])
+        joins_query = build_join_statement(table_name, name, srn, options[:joins])
+        conditions_query = build_condition_statement(reputation_name, options[:conditions])
+        select(select_query).joins(joins_query).where(conditions_query)
+      end
+
       protected
 
         def parse_query_args(*args)

--- a/spec/reputation_system/finder_methods_spec.rb
+++ b/spec/reputation_system/finder_methods_spec.rb
@@ -180,4 +180,17 @@ describe ReputationSystem::FinderMethods do
         "ORDER BY total_votes"
     end
   end
+
+  describe "#scope_with_reputation" do
+    it "should return ActiveRecord::Relation object" do
+      Question.scope_with_reputation(:total_votes, :all
+      ).class.should eq(ActiveRecord::Relation)
+    end
+
+    it "should be a valid scope" do
+      find_results = Question.find_with_reputation(:total_votes, :all)
+      Question.scope_with_reputation(:total_votes, :all
+      ).all.should eq(find_results)
+    end
+  end
 end


### PR DESCRIPTION
Just added #scope_with_reputation in FinderMethods module. 

The effect is similar to #find_with_reputation, with the difference it will return a scoped object instead of Array.

This will help efficiency when dealing with lots of records. 

Also it will be native to work with pagination gems like

```
Question.scope_with_reputation(:total_votes, :all).page(1)
```
