### PR TITLE
Rails 4 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Reputation value can be accessed as follow:
 
 You can query for records using reputation value:
 ```ruby
-User.find_with_reputation(:karma, :all, { :condition => 'karma > 10' })
+User.find_with_reputation(:karma, { :condition => 'karma > 10' })
 ```
 
 You can get source records that have evaluated the target record:

--- a/lib/reputation_system/finder_methods.rb
+++ b/lib/reputation_system/finder_methods.rb
@@ -35,7 +35,7 @@ module FinderMethods
         options[:joins] = build_join_statement(table_name, name, srn, options[:joins])
         options[:conditions] = build_condition_statement(reputation_name, options[:conditions])
         options[:conditions][0].gsub!(reputation_name.to_s, "COALESCE(rs_reputations.value, 0)")
-        joins(options[:joins]).select(options[:select]).where(options[:conditions]).count
+        joins(options[:joins]).where(options[:conditions]).count
       end
 
       def find_with_normalized_reputation(*args)

--- a/lib/reputation_system/finder_methods.rb
+++ b/lib/reputation_system/finder_methods.rb
@@ -23,31 +23,31 @@ module FinderMethods
     module ClassMethods
 
       def find_with_reputation(*args)
-        reputation_name, srn, find_scope, options = parse_query_args(*args)
+        reputation_name, srn, options = parse_query_args(*args)
         options[:select] = build_select_statement(table_name, reputation_name, options[:select])
         options[:joins] = build_join_statement(table_name, name, srn, options[:joins])
         options[:conditions] = build_condition_statement(reputation_name, options[:conditions])
-        joins(options[:joins]).select(options[:select]).where(options[:conditions]).send(find_scope)
+        joins(options[:joins]).select(options[:select]).where(options[:conditions])
       end
 
       def count_with_reputation(*args)
-        reputation_name, srn, find_scope, options = parse_query_args(*args)
+        reputation_name, srn, options = parse_query_args(*args)
         options[:joins] = build_join_statement(table_name, name, srn, options[:joins])
         options[:conditions] = build_condition_statement(reputation_name, options[:conditions])
         options[:conditions][0].gsub!(reputation_name.to_s, "COALESCE(rs_reputations.value, 0)")
-        joins(options[:joins]).select(options[:select]).where(options[:conditions]).send(find_scope).count
+        joins(options[:joins]).select(options[:select]).where(options[:conditions]).count
       end
 
       def find_with_normalized_reputation(*args)
-        reputation_name, srn, find_scope, options = parse_query_args(*args)
+        reputation_name, srn, options = parse_query_args(*args)
         options[:select] = build_select_statement(table_name, reputation_name, options[:select], srn, true)
         options[:joins] = build_join_statement(table_name, name, srn, options[:joins])
         options[:conditions] = build_condition_statement(reputation_name, options[:conditions], srn, true)
-        joins(options[:joins]).select(options[:select]).where(options[:conditions]).send(find_scope)
+        joins(options[:joins]).select(options[:select]).where(options[:conditions])
       end
 
       def find_with_reputation_sql(*args)
-        reputation_name, srn, find_scope, options = parse_query_args(*args)
+        reputation_name, srn, options = parse_query_args(*args)
         options[:select] = build_select_statement(table_name, reputation_name, options[:select])
         options[:joins] = build_join_statement(table_name, name, srn, options[:joins])
         options[:conditions] = build_condition_statement(reputation_name, options[:conditions])
@@ -56,7 +56,7 @@ module FinderMethods
         elsif respond_to?(:construct_finder_arel, true)
           construct_finder_arel(options).to_sql
         else
-          joins(options[:joins]).select(options[:select]).where(options[:conditions]).send(find_scope).to_sql
+          joins(options[:joins]).select(options[:select]).where(options[:conditions]).to_sql
         end
       end
 
@@ -64,22 +64,19 @@ module FinderMethods
 
         def parse_query_args(*args)
           case args.length
-          when 2
-            find_scope = args[1]
+          when 1
             options = {}
+          when 2
+            options = args[1]
           when 3
-            find_scope = args[1]
-            options = args[2]
-          when 4
             scope = args[1]
-            find_scope = args[2]
-            options = args[3]
+            options = args[2]
           else
-            raise ArgumentError, "Expecting 2, 3 or 4 arguments but got #{args.length}"
+            raise ArgumentError, "Expecting 1, 2 or 3 arguments but got #{args.length}"
           end
           reputation_name = args[0]
           srn = ReputationSystem::Network.get_scoped_reputation_name(name, reputation_name, scope)
-          [reputation_name, srn, find_scope, options]
+          [reputation_name, srn, options]
         end
     end
   end

--- a/lib/reputation_system/query_builder.rb
+++ b/lib/reputation_system/query_builder.rb
@@ -23,7 +23,7 @@ module ReputationSystem
     module ClassMethods
       DELTA = 0.000001
       REPUTATION_JOIN_STATEMENT = "LEFT JOIN rs_reputations ON %s.id = rs_reputations.target_id AND rs_reputations.target_type = ? AND rs_reputations.reputation_name = ? AND rs_reputations.active = ?"
-      REPUTATION_FIELD_STRING = "COALESCE(rs_reputations.value, 0)" 
+      REPUTATION_FIELD_STRING = "COALESCE(rs_reputations.value, 0)"
 
       def build_select_statement(table_name, reputation_name, select=nil, srn=nil, normalize=false)
         select = sanitize_sql_array(["%s.*", table_name]) unless select
@@ -54,11 +54,11 @@ module ReputationSystem
       end
 
       def build_join_statement(table_name, class_name, srn, joins=nil)
-          joins ||= []
-          joins = [joins] unless joins.is_a? Array
-          rep_join = sanitize_sql_array([REPUTATION_JOIN_STATEMENT, class_name.to_s, srn.to_s, true])
-          rep_join = sanitize_sql_array([rep_join, table_name])
-          joins << rep_join
+        joins ||= []
+        joins = [joins] unless joins.is_a? Array
+        rep_join = sanitize_sql_array([REPUTATION_JOIN_STATEMENT, class_name.to_s, srn.to_s, true])
+        rep_join = sanitize_sql_array([rep_join, table_name])
+        joins << rep_join
       end
 
       protected

--- a/lib/reputation_system/reputation_methods.rb
+++ b/lib/reputation_system/reputation_methods.rb
@@ -46,7 +46,7 @@ module ReputationSystem
     def rank_for(reputation_name, *args)
       scope = args.first
       my_value = self.reputation_for(reputation_name, scope)
-      self.class.count_with_reputation(reputation_name, scope, :all,
+      self.class.count_with_reputation(reputation_name, scope,
         :conditions => ["rs_reputations.value > ?", my_value]
       ) + 1
     end

--- a/spec/reputation_system/evaluation_methods_spec.rb
+++ b/spec/reputation_system/evaluation_methods_spec.rb
@@ -165,12 +165,12 @@ describe ReputationSystem::EvaluationMethods do
 
       it "should raise exception if the same source evaluates for the same target more than once" do
         @question.add_evaluation(:total_votes, 1, @user)
-        expect { @question.add_evaluation(:total_votes, 1, @user) }.to raise_error
+        expect { @question.add_evaluation(:total_votes, 1, @user) }.to raise_error(ActiveRecord::RecordInvalid)
       end
 
       it "should not allow the same source to add an evaluation for the same target" do
         @question.add_evaluation(:total_votes, 1, @user)
-        expect { @question.add_evaluation(:total_votes, 1, @user) }.to raise_error
+        expect { @question.add_evaluation(:total_votes, 1, @user) }.to raise_error(ActiveRecord::RecordInvalid)
       end
 
       it "should not raise exception if some association has not been initialized along during the propagation of reputation" do
@@ -303,7 +303,7 @@ describe ReputationSystem::EvaluationMethods do
       end
 
       it "should raise exception if evaluation does not exist" do
-        expect { @answer.update_evaluation(:avg_rating, 1, @user) }.to raise_error
+        expect { @answer.update_evaluation(:avg_rating, 1, @user) }.to raise_error(ArgumentError)
       end
 
       context "With Scopes" do
@@ -347,7 +347,7 @@ describe ReputationSystem::EvaluationMethods do
       end
 
       it "should raise exception if evaluation does not exist" do
-        expect { @answer.delete_evaluation!(:avg_rating, @user) }.to raise_error
+        expect { @answer.delete_evaluation!(:avg_rating, @user) }.to raise_error(ArgumentError)
       end
 
       context "With Scopes" do

--- a/spec/reputation_system/finder_methods_spec.rb
+++ b/spec/reputation_system/finder_methods_spec.rb
@@ -32,13 +32,13 @@ describe ReputationSystem::FinderMethods do
       end
 
       it "should return result with given reputation" do
-        res = Question.find_with_reputation(:total_votes, :all, {})
+        res = Question.find_with_reputation(:total_votes, {})
         expect(res).to eq([@question])
         expect(res[0].total_votes).not_to be_nil
       end
 
       it "should retain select option" do
-        res = Question.find_with_reputation(:total_votes, :all, {:select => "questions.id"})
+        res = Question.find_with_reputation(:total_votes, {:select => "questions.id"})
         expect(res).to eq([@question])
         expect(res[0].id).not_to be_nil
         expect(res[0].attributes).not_to include(:text)
@@ -47,12 +47,12 @@ describe ReputationSystem::FinderMethods do
       it "should retain conditions option" do
         @question2 = Question.create!(:text => 'Does this work?', :author_id => @user.id)
         @question2.add_evaluation(:total_votes, 5, @user)
-        res = Question.find_with_reputation(:total_votes, :all, {:conditions => "total_votes > 4"})
+        res = Question.find_with_reputation(:total_votes, {:conditions => "total_votes > 4"})
         expect(res).to eq([@question2])
       end
 
       it "should retain joins option" do
-        res = Question.find_with_reputation(:total_votes, :all, {
+        res = Question.find_with_reputation(:total_votes, {
           :select => "questions.*, users.name AS user_name",
           :joins => "JOIN users ON questions.author_id = users.id"})
         expect(res).to eq([@question])
@@ -69,7 +69,7 @@ describe ReputationSystem::FinderMethods do
       end
 
       it "should return result with given reputation" do
-        res = Phrase.find_with_reputation(:maturity, :ja, :all, {})
+        res = Phrase.find_with_reputation(:maturity, :ja, {})
         expect(res).to eq([@phrase])
         expect(res[0].maturity).to eq(3)
       end
@@ -83,10 +83,10 @@ describe ReputationSystem::FinderMethods do
       end
 
       it "should return result with given reputation" do
-        expect(Question.count_with_reputation(:total_votes, :all, {
+        expect(Question.count_with_reputation(:total_votes, {
           :conditions => "total_votes < 2"
         })).to eq(0)
-        expect(Question.count_with_reputation(:total_votes, :all, {
+        expect(Question.count_with_reputation(:total_votes, {
           :conditions => "total_votes > 2"
         })).to eq(1)
       end
@@ -101,10 +101,10 @@ describe ReputationSystem::FinderMethods do
       end
 
       it "should return result with given reputation" do
-        expect(Phrase.count_with_reputation(:maturity, :ja, :all, {
+        expect(Phrase.count_with_reputation(:maturity, :ja, {
           :conditions => "maturity < 2"
         })).to eq(0)
-        expect(Phrase.count_with_reputation(:maturity, :ja, :all, {
+        expect(Phrase.count_with_reputation(:maturity, :ja, {
           :conditions => "maturity > 2"
         })).to eq(1)
       end
@@ -120,14 +120,14 @@ describe ReputationSystem::FinderMethods do
       it "should return result with given normalized reputation" do
         @question2 = Question.create!(:text => 'Does this work?', :author_id => @user.id)
         @question2.add_evaluation(:total_votes, 6, @user)
-        res = Question.find_with_normalized_reputation(:total_votes, :all, {})
+        res = Question.find_with_normalized_reputation(:total_votes, {})
         expect(res).to eq([@question, @question2])
         expect(res[0].normalized_total_votes).to be_within(DELTA).of(0)
         expect(res[1].normalized_total_votes).to be_within(DELTA).of(1)
       end
 
       it "should retain select option" do
-        res = Question.find_with_normalized_reputation(:total_votes, :all, {:select => "questions.id"})
+        res = Question.find_with_normalized_reputation(:total_votes, {:select => "questions.id"})
         expect(res).to eq([@question])
         expect(res[0].id).not_to be_nil
         expect(res[0].attributes).not_to include(:text)
@@ -136,12 +136,12 @@ describe ReputationSystem::FinderMethods do
       it "should retain conditions option" do
         @question2 = Question.create!(:text => 'Does this work?', :author_id => @user.id)
         @question2.add_evaluation(:total_votes, 6, @user)
-        res = Question.find_with_normalized_reputation(:total_votes, :all, {:conditions => "normalized_total_votes > 0.6"})
+        res = Question.find_with_normalized_reputation(:total_votes, {:conditions => "normalized_total_votes > 0.6"})
         expect(res).to eq([@question2])
       end
 
       it "should retain joins option" do
-        res = Question.find_with_normalized_reputation(:total_votes, :all, {
+        res = Question.find_with_normalized_reputation(:total_votes, {
           :select => "questions.*, users.name AS user_name",
           :joins => "JOIN users ON questions.author_id = users.id"})
         expect(res).to eq([@question])
@@ -158,7 +158,7 @@ describe ReputationSystem::FinderMethods do
       end
 
       it "should return result with given reputation" do
-        res = Phrase.find_with_normalized_reputation(:maturity, :ja, :all, {})
+        res = Phrase.find_with_normalized_reputation(:maturity, :ja, {})
         expect(res).to eq([@phrase])
         expect(res[0].normalized_maturity).to be_within(DELTA).of(0)
       end
@@ -167,7 +167,7 @@ describe ReputationSystem::FinderMethods do
 
   describe "#find_with_reputation_sql" do
     it "should return a corresponding sql statement" do
-      sql = Question.find_with_reputation_sql(:total_votes, :all, {
+      sql = Question.find_with_reputation_sql(:total_votes, {
         :select => "questions.*, users.name AS user_name",
         :joins => "JOIN users ON questions.author_id = users.id",
         :conditions => "COALESCE(rs_reputations.value, 0) > 0.6",

--- a/spec/reputation_system/finder_methods_spec.rb
+++ b/spec/reputation_system/finder_methods_spec.rb
@@ -41,7 +41,7 @@ describe ReputationSystem::FinderMethods do
         res = Question.find_with_reputation(:total_votes, :all, {:select => "questions.id"})
         expect(res).to eq([@question])
         expect(res[0].id).not_to be_nil
-        expect {res[0].text}.to raise_error
+        expect(res[0].attributes).not_to include(:text)
       end
 
       it "should retain conditions option" do
@@ -130,7 +130,7 @@ describe ReputationSystem::FinderMethods do
         res = Question.find_with_normalized_reputation(:total_votes, :all, {:select => "questions.id"})
         expect(res).to eq([@question])
         expect(res[0].id).not_to be_nil
-        expect {res[0].text}.to raise_error
+        expect(res[0].attributes).not_to include(:text)
       end
 
       it "should retain conditions option" do

--- a/spec/reputation_system/models/evaluation_spec.rb
+++ b/spec/reputation_system/models/evaluation_spec.rb
@@ -28,7 +28,7 @@ describe ReputationSystem::Evaluation do
     end
     it "should not be able to create an evaluation from given source if it has already evaluated the same reputation of the target" do
       ReputationSystem::Evaluation.create!(@attributes)
-      expect {ReputationSystem::Evaluation.create!(@attributes)}.to raise_error
+      expect {ReputationSystem::Evaluation.create!(@attributes)}.to raise_error(ActiveRecord::RecordInvalid)
     end
   end
 

--- a/spec/reputation_system/query_methods_spec.rb
+++ b/spec/reputation_system/query_methods_spec.rb
@@ -56,7 +56,7 @@ describe ReputationSystem::QueryMethods do
         res = Question.with_reputation(:total_votes).select("questions.id")
         expect(res).to eq([@question])
         expect(res[0].id).not_to be_nil
-        expect {res[0].text}.not_to raise_error
+        expect(res[0].attributes).not_to include(:text)
       end
     end
 
@@ -107,7 +107,7 @@ describe ReputationSystem::QueryMethods do
         res = Question.with_reputation_only(:total_votes).select("questions.id")
         expect(res).to eq([@question])
         expect(res[0].id).not_to be_nil
-        expect {res[0].text}.to raise_error
+        expect(res[0].attributes).not_to include(:text)
       end
     end
 
@@ -146,7 +146,7 @@ describe ReputationSystem::QueryMethods do
         res = Question.with_normalized_reputation(:total_votes).select("questions.id")
         expect(res).to eq([@question])
         expect(res[0].id).not_to be_nil
-        expect {res[0].text}.not_to raise_error
+        expect(res[0].attributes).not_to include(:text)
       end
 
       it "should retain conditions option" do
@@ -200,7 +200,7 @@ describe ReputationSystem::QueryMethods do
         res = Question.with_normalized_reputation_only(:total_votes).select("questions.id")
         expect(res.length).to eq(1)
         expect(res[0].id).not_to be_nil
-        expect {res[0].text}.to raise_error
+        expect(res[0].attributes).not_to include(:text)
       end
 
       it "should retain conditions option" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,7 +44,7 @@ ActiveRecord::Schema.define do
     t.references  :target, :polymorphic => true
     t.float       :value, :default => 0
     t.text        :data
-    t.timestamps
+    t.timestamps  :null => false
   end
 
   add_index :rs_evaluations, :reputation_name
@@ -58,7 +58,7 @@ ActiveRecord::Schema.define do
     t.references  :target, :polymorphic => true
     t.boolean     :active, :default => true
     t.text        :data
-    t.timestamps
+    t.timestamps  :null => false
   end
 
   add_index :rs_reputations, :reputation_name
@@ -68,53 +68,45 @@ ActiveRecord::Schema.define do
     t.references  :sender, :polymorphic => true
     t.integer     :receiver_id
     t.float       :weight, :default => 1
-    t.timestamps
-  end
+    t.timestamps  :null => false  end
 
   add_index :rs_reputation_messages, [:sender_id, :sender_type]
   add_index :rs_reputation_messages, :receiver_id
 
   create_table :users do |t|
     t.string :name
-    t.timestamps
-  end
+    t.timestamps  :null => false  end
 
   create_table :answers do |t|
     t.integer :author_id
     t.integer :question_id
     t.string :text
-    t.timestamps
-  end
+    t.timestamps  :null => false  end
 
   create_table :questions do |t|
     t.integer :author_id
     t.string :text
-    t.timestamps
-  end
+    t.timestamps  :null => false  end
 
   create_table :phrases do |t|
     t.string :text
-    t.timestamps
-  end
+    t.timestamps  :null => false  end
 
   create_table :translations do |t|
     t.integer :user_id
     t.integer :phrase_id
     t.string  :text
     t.string  :locale
-    t.timestamps
-  end
+    t.timestamps  :null => false  end
 
   create_table :people do |t|
     t.string :name
     t.string :type
-    t.timestamps
-  end
+    t.timestamps  :null => false  end
 
   create_table :posts do |t|
     t.string :name
-    t.timestamps
-  end
+    t.timestamps  :null => false  end
 end
 
 class User < ActiveRecord::Base


### PR DESCRIPTION
1. In spec, expecting by .raise_error without error type is deprecated as it can cause false positive. So, I added expected error types and replace unnecessary error expectation to attribute checks
2. In Rails4, there's no difference between `.scoped` and `.all`. Both returns active relation. In doing so, we don't need to specify `find_scope` any more for FinderMethods methods. Also the existing behavior for it doesn't give us any benefit. It just calls the scope at the end of query result.
